### PR TITLE
feat: 변경된 리액트 상태 정보를 API로 전송 처리 (#25)

### DIFF
--- a/src/puppeteer/stateTracker.js
+++ b/src/puppeteer/stateTracker.js
@@ -54,12 +54,31 @@ export const trackStateChanges = async (page) => {
         return true;
       };
 
+      const getStateData = (fiber) => {
+        const stateData = {};
+        let currentState = fiber.memoizedState;
+        let index = 0;
+
+        while (currentState) {
+          const prevState = currentState.alternate?.memoizedState;
+          if (
+            isValidState(currentState.memoizedState) &&
+            JSON.stringify(currentState.memoizedState) !== JSON.stringify(prevState)
+          ) {
+            stateData[`state_${index}`] = currentState.memoizedState;
+          }
+          currentState = currentState.next;
+          index++;
+        }
+        return stateData;
+      };
+
       const traverseFiberTree = (fiberNode) => {
         const newState = {};
         while (fiberNode) {
           if (fiberNode.memoizedState) {
             const componentName = fiberNode.type?.name || "Anonymous";
-            const stateData = fiberNode.memoizedState.memoizedState;
+            const stateData = getStateData(fiberNode);
 
             if (isValidState(stateData)) {
               newState[componentName] = stateData;

--- a/src/puppeteer/stateTracker.js
+++ b/src/puppeteer/stateTracker.js
@@ -117,10 +117,23 @@ export const trackStateChanges = async (page) => {
         }
       };
 
-      const observer = new MutationObserver(detectStateChange);
-      const rootElement = document.getElementById("root") || document.getElementById("app");
-      if (rootElement) {
-        observer.observe(rootElement, { childList: true, subtree: true });
+      const fiberRoot = getFiberRoot();
+      if (fiberRoot) {
+        detectStateChange();
+
+        let fiberNode = fiberRoot.child;
+        while (fiberNode) {
+          const alternate = fiberNode.alternate;
+
+          if (
+            alternate &&
+            JSON.stringify(fiberNode.memoizedState) !== JSON.stringify(alternate.memoizedState)
+          ) {
+            detectStateChange();
+          }
+
+          fiberNode = fiberNode.sibling;
+        }
       }
 
       return "Puppeteer evaluate 실행 완료!";


### PR DESCRIPTION
## 이슈

> #25

<br/>

## 작업 내용 요약

> 리액트 fiber tree에서 상태 변화를 감지합니다.
> 
> 상태가 변경되는 경우, API 서버로 데이터를 전송합니다.
> 
> API 서버는 POST /states로 전송합니다.

<br />

### 스크린샷 (선택)

<br />

## 참고사항

<br />

## PR 체크 리스트

- [X] PR에 대한 명확한 설명을 작성하였습니다.
- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 준수하였습니다.
- [X] 브랜치 명을 확인하였습니다.
- [X] 필요한 경우 관련 이슈 번호를 PR에 연결하였습니다.
- [X] 기능 및 동작을 테스트하고 예상대로 작동하는지 테스트하였습니다.

<br />

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
