### PR TITLE
fix: 상태가 한번만 불려오고 추적되지 않던 현상 해결 (#41)

### DIFF
--- a/src/puppeteer/stateTracker.js
+++ b/src/puppeteer/stateTracker.js
@@ -22,6 +22,7 @@ export const trackStateChanges = async (page) => {
       };
 
       const isValidState = (stateValue) => {
+        if (stateValue === null) return true;
         if (typeof stateValue !== "object") return true;
 
         const invalidKeys = new Set([
@@ -42,12 +43,11 @@ export const trackStateChanges = async (page) => {
         }
 
         if (Array.isArray(stateValue)) {
-          const filteredArray = stateValue.filter((element) => {
-            if (typeof element !== "object") return true;
-            if ("rootComponent" in element) return false;
-          });
-
-          return filteredArray.length > 0;
+          for (const element of stateValue) {
+            if (element && typeof element === "object" && "rootComponent" in element) {
+              return false;
+            }
+          }
         }
 
         return true;
@@ -59,17 +59,13 @@ export const trackStateChanges = async (page) => {
         let index = 0;
 
         while (currentState) {
-          const prevState = currentState.alternate?.memoizedState;
-
-          if (
-            isValidState(currentState.memoizedState) &&
-            JSON.stringify(currentState.memoizedState) !== JSON.stringify(prevState)
-          ) {
+          if (isValidState(currentState.memoizedState)) {
             stateData[`state_${index}`] = currentState.memoizedState;
           }
           currentState = currentState.next;
           index++;
         }
+
         return stateData;
       };
 
@@ -85,7 +81,17 @@ export const trackStateChanges = async (page) => {
               newState[componentName] = stateData;
             }
           }
-          fiberNode = fiberNode.child;
+
+          if (fiberNode.child) {
+            fiberNode = fiberNode.child;
+          } else {
+            while (fiberNode && !fiberNode.sibling) {
+              fiberNode = fiberNode.return;
+            }
+            if (fiberNode) {
+              fiberNode = fiberNode.sibling;
+            }
+          }
         }
         return newState;
       };
@@ -101,7 +107,6 @@ export const trackStateChanges = async (page) => {
           console.log("상태 변경 감지됨:", newState);
 
           const domTree = document.documentElement.outerHTML;
-          const state = newState;
 
           try {
             await fetch(`${apiUrl}/states`, {
@@ -109,7 +114,7 @@ export const trackStateChanges = async (page) => {
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
                 timestamp: new Date().toISOString(),
-                state,
+                state: newState,
                 dom: domTree,
               }),
             });
@@ -122,20 +127,6 @@ export const trackStateChanges = async (page) => {
       const fiberRoot = getFiberRoot();
       if (fiberRoot) {
         detectStateChange();
-
-        let fiberNode = fiberRoot.child;
-        while (fiberNode) {
-          const alternate = fiberNode.alternate;
-
-          if (
-            alternate &&
-            JSON.stringify(fiberNode.memoizedState) !== JSON.stringify(alternate.memoizedState)
-          ) {
-            detectStateChange();
-          }
-
-          fiberNode = fiberNode.sibling;
-        }
       }
 
       const root = document.getElementById("root") || document.getElementById("app");
@@ -147,8 +138,10 @@ export const trackStateChanges = async (page) => {
           childList: true,
           subtree: true,
           attributes: true,
+          characterData: true,
         });
       }
+
       detectStateChange();
 
       return "Puppeteer evaluate 실행 완료!";


### PR DESCRIPTION
<!--
  아래의 목록을 기준으로 작업 단위를 나누어 주세요.
  1. 작업 단위가 독립적인 기능으로 동작 가능한가요?
  2. PR 제목이 명확하고 간결한가요?
  3. 이 작업 만으로 코드리뷰가 쉽고 명확한가요? PR 단위가 너무 크진 않은가요?
  4. 리뷰어 입장에서 명확히 이해할 수 있는 작업 단위인가요?
-->
## 관련 이슈

#41 

<br/>

## PR 생성 목적

1. 처음 상태만 감지되고 이후 상태 변경이 감지되지 않는 현상을 해결하기 위해 fibernode의 자식뿐만아니라 형제 컴포넌트까지 탐색하도록 했습니다. 
2. MutationObserver의 옵션 중 `characterData: true`를 추가하여 텍스트가 바뀌어도 감지하도록 했습니다. 
3. isValidState 에서 null의 타입이 object이기 때문에 stateValue가 null 인 경우에도 Object.keys(null)을 실행하게 되었고 이로 인해 TypeError가 발생했습니다. 이 에러를 고치기 위해 `if (stateValue === null) return true;`를 추가해주었습니다.


<br/>

## 작업 사유

처음 상태만 감지되고 이후 상태 변경이 감지되지 않는 현상을 해결하기 위해 PR 생성했습니다.

<br />


## 논의 사항

![image](https://github.com/user-attachments/assets/1313b202-8eef-4d51-92d9-595e01dcf1fa)
처음 내부 상태키가 빈배열로 들어와서 거르지 못한 상태입니다.
![image](https://github.com/user-attachments/assets/a2397f90-1f3c-4f1e-9833-143bc88595b8)
추후에 내부상태키인것을 인지하고 없어진 상태입니다.

빈배열일때 상태를 필터링하지 못하기 때문에 이 문제에 대해서 논의해야할 것 같습니다.


<br />

## PR 체크 리스트

- [X] PR에 대한 명확한 설명을 작성하였습니다.
- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 준수하였습니다.
- [X] 브랜치 명을 확인하였습니다.
- [X] 필요한 경우 관련 이슈 번호를 PR에 연결하였습니다.
- [X] 기능 및 동작을 테스트하고 예상대로 작동하는지 테스트하였습니다.

<br />

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
