### PR TITLE
feat: 상태 변경 시 DOM 트리 저장 기능 구현

### DIFF
--- a/src/puppeteer/stateTracker.js
+++ b/src/puppeteer/stateTracker.js
@@ -6,6 +6,7 @@ export const trackStateChanges = async (page) => {
 
     const evaluationResult = await page.evaluate(async (apiUrl) => {
       window.snapbugState = {};
+      window.snapbugPreviousDomHash = null;
 
       const getFiberRoot = () => {
         const elements = document.body.children;
@@ -96,6 +97,14 @@ export const trackStateChanges = async (page) => {
         return newState;
       };
 
+      const getDOMHash = async (domString) => {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(domString);
+        const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+      };
+
       const detectStateChange = async () => {
         const fiberRoot = getFiberRoot();
         if (!fiberRoot) return;
@@ -106,7 +115,15 @@ export const trackStateChanges = async (page) => {
           window.snapbugState = newState;
           console.log("상태 변경 감지됨:", newState);
 
-          const domTree = document.documentElement.outerHTML;
+          const root = document.getElementById("root") || document.getElementById("app");
+          const domTree = root?.outerHTML || "";
+
+          const currentHash = await getDOMHash(domTree);
+          const isDomChanged = currentHash !== window.snapbugPreviousDomHash;
+
+          if (isDomChanged) {
+            window.snapbugPreviousDomHash = currentHash;
+          }
 
           try {
             await fetch(`${apiUrl}/states`, {
@@ -115,7 +132,7 @@ export const trackStateChanges = async (page) => {
               body: JSON.stringify({
                 timestamp: new Date().toISOString(),
                 state: newState,
-                dom: domTree,
+                dom: isDomChanged ? domTree : null,
               }),
             });
           } catch (error) {


### PR DESCRIPTION

## 관련 이슈
#27 

<br/>

## PR 생성 목적
상태 히스토리에 따른 돔을 렌더링하여 보여주기 위해 JSON으로 돔트리를 저장


<br/>

## 작업 사유
돔 트리 정보를 저장 후 히스토리 시점의 돔트리를 렌더링하기 위해 작업하였습니다.


<br />

## 스크린샷
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/8d4dc3b2-a267-4823-993c-e76973b7037d" />


<br />

## 논의 사항
- 상태 정보를 모두 저장해야하는지 논의가 필요합니다.
- POST 요청 시 body 부분 용량 관련하여 에러 가 발생하여 논의가 필요합니다.
- cors 관련하여 에러처리가 필요해 보입니다.


<br />

## PR 체크 리스트

- [X] PR에 대한 명확한 설명을 작성하였습니다.
- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 준수하였습니다.
- [X] 브랜치 명을 확인하였습니다.
- [X] 필요한 경우 관련 이슈 번호를 PR에 연결하였습니다.
- [X] 기능 및 동작을 테스트하고 예상대로 작동하는지 테스트하였습니다.

<br />